### PR TITLE
[DK-002] Add caching to product metrics endpoint

### DIFF
--- a/daikon/api.py
+++ b/daikon/api.py
@@ -1,14 +1,17 @@
 from flask import Flask, jsonify, request
+from flask_caching import Cache
 from daikon.model.product_metrics import db, ma, ProductMetrics, ProductMetricsSchema
 from daikon.auth import auth_required
 from datetime import datetime
-
 import os
 
 app = Flask(__name__)
 app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("SQLALCHEMY_DATABASE_URI")
 db.init_app(app)
 ma.init_app(app)
+
+cache = Cache(config={"DEBUG": True, "CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 604800})
+cache.init_app(app)
 
 
 @app.route("/stores/<int:id>", methods=["GET"])
@@ -23,7 +26,8 @@ def get_product_listings(id):
     pass
 
 
-@app.route("/v1/product-metrics/search", methods=["GET"])
+@app.route("/product-metrics/search", methods=["GET"])
+@cache.cached(timeout=604800, query_string=True)
 def get_product_metrics():
     query_params = request.args
 

--- a/daikon/test/e2e/test_api_caching.py
+++ b/daikon/test/e2e/test_api_caching.py
@@ -1,0 +1,50 @@
+import requests
+import os
+import psycopg2
+
+DAIKON_HOST_URL = os.environ.get("DAIKON_HOST_URL")
+PG_HOST = os.environ.get("DAIKON_PG_HOST")
+PG_PORT = os.environ.get("DAIKON_PG_PORT")
+PG_DBNAME = os.environ.get("DAIKON_PG_DBNAME")
+PG_USERNAME = os.environ.get("DAIKON_PG_USERNAME")
+PG_PASSWORD = os.environ.get("DAIKON_PG_PASSWORD")
+
+
+def test_api_caching():
+    url = DAIKON_HOST_URL + "/product-metrics/search"
+    params = {"start_date": "2023-01-01", "end_date": "2023-01-01", "product_id": 1, "region_code": "ON"}
+    response = requests.get(url, params=params)
+
+    data = response.json()
+
+    assert data[0]["avg_price"] == "6.09"
+
+    def temp_set_price(price_val, **params):
+        ddl = """
+            update wolfram.product_timeseries_metrics
+            set avg_price = {price_val}
+            where calendar_date between '{start_date}' and '{end_date}'
+              and product_id = {product_id} and region_code='{region_code}'
+        """.format(
+            price_val=price_val,
+            start_date=params["start_date"],
+            end_date=params["end_date"],
+            product_id=params["product_id"],
+            region_code=params["region_code"],
+        )
+
+        conn = psycopg2.connect(host=PG_HOST, database=PG_DBNAME, user=PG_USERNAME, password=PG_PASSWORD, port=PG_PORT)
+        cur = conn.cursor()
+        cur.execute(ddl)
+
+    assert data[0]["avg_price"] == "6.09"
+
+    temp_set_price(6.10, **params)
+
+    response2 = requests.get(url, params=params)
+
+    data2 = response2.json()
+
+    assert data2[0]["avg_price"] == "6.09"
+
+    temp_set_price(6.09, **params)

--- a/daikon/test/e2e/test_api_endpoint.py
+++ b/daikon/test/e2e/test_api_endpoint.py
@@ -1,0 +1,41 @@
+import requests
+import os
+
+DAIKON_HOST_URL = os.environ.get("DAIKON_HOST_URL")
+
+
+def test_api_product_metrics_search_endpoint():
+    url = DAIKON_HOST_URL + "/product-metrics/search"
+    params = {"start_date": "2023-01-01", "end_date": "2023-01-02", "product_id": 1, "region_code": "ON"}
+    response = requests.get(url, params=params)
+
+    data = response.json()
+
+    expected_data = [
+        {
+            "avg_price": "6.10",
+            "avg_price_chng": "0.01",
+            "calendar_date": "2023-01-02",
+            "currency": "CAD",
+            "md5_key": "1e4df936c94cc8f88cea811629cce539",
+            "product_id": 1,
+            "product_listings": 101,
+            "product_listings_rtn": 98,
+            "region_code": "ON",
+            "unit": "/ 1kg",
+        },
+        {
+            "avg_price": "6.09",
+            "avg_price_chng": "0.01",
+            "calendar_date": "2023-01-01",
+            "currency": "CAD",
+            "md5_key": "bd5f438be66323636bb227a81460d197",
+            "product_id": 1,
+            "product_listings": 100,
+            "product_listings_rtn": 98,
+            "region_code": "ON",
+            "unit": "/ 1kg",
+        },
+    ]
+
+    assert expected_data == data


### PR DESCRIPTION
What: Adds simple caching to the request routing using a decorator and tests for some basic end to end behaviors of the cached requests on the seeded data.

Why: Limits reads on the database.