### PR TITLE
Add to api statcan cpi monthly

### DIFF
--- a/daikon/model/statcan_cpi_monthly.py
+++ b/daikon/model/statcan_cpi_monthly.py
@@ -1,0 +1,38 @@
+from daikon.model import db, ma
+
+
+class StatcanCPIMonthly(db.Model):
+    __table_args__ = {"schema": "stahl"}
+    __tablename__ = "statcan_cpi_monthly"
+
+    calendar_date = db.Column(db.Date())
+    time_grain = db.Column(db.String())
+    region_code = db.Column(db.String(2))
+    component_name = db.Column(db.String())
+    cpi = db.Column(db.Numeric(32, 2))
+    previous_cpi = db.Column(db.Numeric(32, 2))
+    cpi_chng = db.Column(db.Numeric(32, 4))
+    r_uom = db.Column(db.String())
+    r_dguid = db.Column(db.String())
+
+    md5_key = db.Column(db.String(32), primary_key=True)
+
+    def __repr__(self):
+        return "<Post %s>" % self.title
+
+
+class StatcanCPIMonthlySchema(ma.Schema):
+    class Meta:
+        fields = (
+            "calendar_date",
+            "time_grain",
+            "region_code",
+            "component_name",
+            "cpi",
+            "previous_cpi",
+            "cpi_chng",
+            "r_uom",
+            "r_dguid",
+            "md5_key",
+        )
+        model = StatcanCPIMonthly

--- a/seeds/20231012_createstatcancpimonthly_0000.down.sql
+++ b/seeds/20231012_createstatcancpimonthly_0000.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE stahl.statcan_cpi_monthly;
+
+COMMIT;

--- a/seeds/20231012_createstatcancpimonthly_0000.up.sql
+++ b/seeds/20231012_createstatcancpimonthly_0000.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+CREATE TABLE stahl.statcan_cpi_monthly (
+    calendar_date DATE,
+    time_grain TEXT,
+    region_code CHAR(2),
+    component_name TEXT,
+    cpi NUMERIC(32,2),
+    previous_cpi NUMERIC(32,2),
+    cpi_chng NUMERIC(32,4),
+    r_dguid TEXT,
+    r_uom TEXT,
+    md5_key CHAR(32) PRIMARY KEY
+);
+
+INSERT INTO stahl.statcan_cpi_monthly VALUES
+    ('2023-01-01', 'monthly', 'ON', 'Food', 100.20, 99.20, 1.0000, '1', '2002=100', md5('10000'));
+
+COMMIT;


### PR DESCRIPTION
What: This binds the cpi monthly table from scopuli to the API. Pardon the diff on `api.py`, it had the windows carriage character that should've been changed.