### PR TITLE
Extending api to for census division parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ seed-local-db-up: scripts/seed.sh
 	PG_PASSWORD=${SCOPULI_LOCAL_PG_PASSWORD} \
 	SEED_OPTION=up ENV=local scripts/seed.sh
 
+seed-local-db-down: scripts/seed.sh
+	PG_HOST=${SCOPULI_LOCAL_PG_HOST} \
+	PG_USERNAME=${SCOPULI_LOCAL_PG_USERNAME} \
+	PG_PORT=${SCOPULI_LOCAL_PG_PORT} \
+	PG_DBNAME=${SCOPULI_LOCAL_PG_DBNAME} \
+	PG_PASSWORD=${SCOPULI_LOCAL_PG_PASSWORD} \
+	SEED_OPTION=down ENV=local scripts/seed.sh
+
 bootstrap-prod-remote: scripts/bootstrap.sh
 	export DAIKON_SSH_KEY=$(< "${DAIKON_SSH_KEY_FILEPATH}")
 	ssh -o StrictHostKeyChecking=no ${DAIKON_PROD_HOST} \

--- a/daikon/api.py
+++ b/daikon/api.py
@@ -56,16 +56,18 @@ def get_product_metrics():
     if (not census_division_name is None) and (region_code is None):
         return (
             jsonify(
-                {"error": "census_division_name cannot be passed without region_code, refer to https://tm41m.io/docs/daikon/product_timeseries_metrics.html"}
+                {
+                    "error": "census_division_name cannot be passed without region_code, refer to https://tm41m.io/docs/daikon/product_timeseries_metrics.html"
+                }
             ),
             400,
         )
-    
+
     product_metrics = (
         ProductMetrics.query.filter(ProductMetrics.product_id == product_id)
-            .filter(ProductMetrics.region_code == region_code)
-            .filter(ProductMetrics.census_division_name == census_division_name)
-            .filter(ProductMetrics.calendar_date.between(start_date, end_date))
+        .filter(ProductMetrics.region_code == region_code)
+        .filter(ProductMetrics.census_division_name == census_division_name)
+        .filter(ProductMetrics.calendar_date.between(start_date, end_date))
     )
 
     res = product_metrics.all()
@@ -73,7 +75,7 @@ def get_product_metrics():
     output = schema.dump(res)
 
     return jsonify(output), 200
-    
+
 
 @app.route("/statcan-cpi-monthly/search", methods=["GET"])
 @cache.cached(timeout=604800, query_string=True)

--- a/daikon/api.py
+++ b/daikon/api.py
@@ -53,6 +53,14 @@ def get_product_metrics():
     census_division_name = query_params.get("census_division_name", None)
     end_date = query_params.get("end_date", datetime.now().strftime("%Y-%m-%d"))
 
+    if (not census_division_name is None) and (region_code is None):
+        return (
+            jsonify(
+                {"error": "census_division_name cannot be passed without region_code, refer to https://tm41m.io/docs/daikon/product_timeseries_metrics.html"}
+            ),
+            400,
+        )
+    
     product_metrics = (
         ProductMetrics.query.filter(ProductMetrics.product_id == product_id)
             .filter(ProductMetrics.region_code == region_code)

--- a/daikon/api.py
+++ b/daikon/api.py
@@ -50,12 +50,14 @@ def get_product_metrics():
         )
 
     region_code = query_params.get("region_code", None)
+    census_division_name = query_params.get("census_division_name", None)
     end_date = query_params.get("end_date", datetime.now().strftime("%Y-%m-%d"))
 
     product_metrics = (
         ProductMetrics.query.filter(ProductMetrics.product_id == product_id)
-        .filter(ProductMetrics.region_code == region_code)
-        .filter(ProductMetrics.calendar_date.between(start_date, end_date))
+            .filter(ProductMetrics.region_code == region_code)
+            .filter(ProductMetrics.census_division_name == census_division_name)
+            .filter(ProductMetrics.calendar_date.between(start_date, end_date))
     )
 
     res = product_metrics.all()
@@ -63,7 +65,7 @@ def get_product_metrics():
     output = schema.dump(res)
 
     return jsonify(output), 200
-
+    
 
 @app.route("/statcan-cpi-monthly/search", methods=["GET"])
 @cache.cached(timeout=604800, query_string=True)

--- a/daikon/model/product_metrics.py
+++ b/daikon/model/product_metrics.py
@@ -26,6 +26,7 @@ class ProductMetricsSchema(ma.Schema):
         fields = (
             "calendar_date",
             "region_code",
+            "census_division_name",
             "product_id",
             "currency",
             "unit",

--- a/daikon/model/product_metrics.py
+++ b/daikon/model/product_metrics.py
@@ -7,6 +7,7 @@ class ProductMetrics(db.Model):
 
     calendar_date = db.Column(db.Date())
     region_code = db.Column(db.String())
+    census_division_name = db.Column(db.String())
     product_id = db.Column(db.Integer())
     currency = db.Column(db.String())
     unit = db.Column(db.String())

--- a/daikon/test/e2e/test_api_endpoint.py
+++ b/daikon/test/e2e/test_api_endpoint.py
@@ -10,24 +10,13 @@ def test_api_product_metrics_search_endpoint():
     response = requests.get(url, params=params)
 
     data = response.json()
-
+    
     expected_data = [
         {
-            "avg_price": "6.10",
-            "avg_price_chng": "0.01",
-            "calendar_date": "2023-01-02",
-            "currency": "CAD",
-            "md5_key": "1e4df936c94cc8f88cea811629cce539",
-            "product_id": 1,
-            "product_listings": 101,
-            "product_listings_rtn": 98,
-            "region_code": "ON",
-            "unit": "/ 1kg",
-        },
-        {
             "avg_price": "6.09",
-            "avg_price_chng": "0.01",
+            "avg_price_chng": "0.010000",
             "calendar_date": "2023-01-01",
+            "census_division_name": None,
             "currency": "CAD",
             "md5_key": "bd5f438be66323636bb227a81460d197",
             "product_id": 1,
@@ -36,6 +25,26 @@ def test_api_product_metrics_search_endpoint():
             "region_code": "ON",
             "unit": "/ 1kg",
         },
+        {
+            "avg_price": "6.10",
+            "avg_price_chng": "0.010000",
+            "calendar_date": "2023-01-02",
+            "census_division_name": None,
+            "currency": "CAD",
+            "md5_key": "1e4df936c94cc8f88cea811629cce539",
+            "product_id": 1,
+            "product_listings": 101,
+            "product_listings_rtn": 98,
+            "region_code": "ON",
+            "unit": "/ 1kg",
+        }
     ]
 
     assert expected_data == data
+
+    params2 = {"start_date": "2023-01-01", "end_date": "2023-01-02", "product_id": 1, "census_division_name": "Wellington"}
+    response2 = requests.get(url, params=params2)
+
+    data2 = response2.json()
+
+    assert data2 == {"error":"census_division_name cannot be passed without region_code, refer to https://tm41m.io/docs/daikon/product_timeseries_metrics.html"}

--- a/seeds/20230807_createproductmetrics_0000.up.sql
+++ b/seeds/20230807_createproductmetrics_0000.up.sql
@@ -5,6 +5,7 @@ CREATE SCHEMA wolfram;
 CREATE TABLE wolfram.product_timeseries_metrics (
     calendar_date DATE,
     region_code CHAR(2),
+    census_division_name TEXT,
     product_id BIGINT,
     currency CHAR(3),
     unit VARCHAR(10),
@@ -16,9 +17,11 @@ CREATE TABLE wolfram.product_timeseries_metrics (
 );
 
 INSERT INTO wolfram.product_timeseries_metrics VALUES
-    ('2023-01-01', 'ON', 1, 'CAD', '/ 1kg', 6.09, 0.01, 100, 98, md5('2023-01-01' || '1' || 'ON')),
-    ('2023-01-02', 'ON', 1, 'CAD', '/ 1kg', 6.10, 0.01, 101, 98, md5('2023-01-02' || '1' || 'ON')),
-    ('2023-01-01', null, 1, 'CAD', '/ 1kg', 6.00, 0.01, 120, 98, md5('2023-01-01' || '1' || '')),
-    ('2023-01-02', null, 1, 'CAD', '/ 1kg', 6.01, 0.01, 121, 98, md5('2023-01-02' || '1' || ''));
+    ('2023-01-01', 'ON', 'Wellington', 1, 'CAD', '/ 1kg', 6.45, 0.01, 110, 98, md5('2023-01-01' || '1' || 'ON' || 'Wellington')),
+    ('2023-01-02', 'ON', 'Wellington', 1, 'CAD', '/ 1kg', 6.46, 0.01, 111, 98, md5('2023-01-02' || '1' || 'ON' || 'Wellington')),
+    ('2023-01-01', 'ON', null, 1, 'CAD', '/ 1kg', 6.09, 0.01, 100, 98, md5('2023-01-01' || '1' || 'ON' || '')),
+    ('2023-01-02', 'ON', null, 1, 'CAD', '/ 1kg', 6.10, 0.01, 101, 98, md5('2023-01-02' || '1' || 'ON' || '')),
+    ('2023-01-01', null, null, 1, 'CAD', '/ 1kg', 6.00, 0.01, 120, 98, md5('2023-01-01' || '1' || '' || '')),
+    ('2023-01-02', null, null, 1, 'CAD', '/ 1kg', 6.01, 0.01, 121, 98, md5('2023-01-02' || '1' || '' || ''));
 
 COMMIT;

--- a/seeds/20230816_createstatcanfoodprices_0000.down.sql
+++ b/seeds/20230816_createstatcanfoodprices_0000.down.sql
@@ -2,6 +2,4 @@ BEGIN;
 
 DROP TABLE stahl.statcan_food_prices;
 
-DROP SCHEMA stahl;
-
 COMMIT;

--- a/seeds/20231012_createstatcancpimonthly_0000.down.sql
+++ b/seeds/20231012_createstatcancpimonthly_0000.down.sql
@@ -2,4 +2,6 @@ BEGIN;
 
 DROP TABLE stahl.statcan_cpi_monthly;
 
+DROP SCHEMA stahl;
+
 COMMIT;


### PR DESCRIPTION
There is now functionality for a `census_division_name` parameter in a `product-metrics/search` request. The request will return an error if client provides only a census division name without the corresponding region name. Modified endpoint testing and local db seeding. 